### PR TITLE
Fix latest rack requires ruby 2.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/manifests/capistrano.pp
+++ b/manifests/capistrano.pp
@@ -13,7 +13,19 @@ class deploynaut::capistrano {
 		provider => "gem",
 		notify => Exec["update_rubygems"]
 	} ->
-	package { "net-ssh":
+  package { "rack":
+    ensure => "1.6.6",
+    provider => "gem",
+  } ->
+  package { "vegas":
+    ensure => "0.1.11",
+    provider => "gem",
+  } ->
+  package { "sinatra":
+    ensure => "1.4.8",
+    provider => "gem",
+  } ->
+  package { "net-ssh":
 		ensure => "3.1.1",
 		provider => "gem"
 	} ->

--- a/manifests/capistrano.pp
+++ b/manifests/capistrano.pp
@@ -1,45 +1,45 @@
 class deploynaut::capistrano {
 
-	exec { "update_rubygems":
-		path => '/usr/local/bin:/usr/bin:/usr/sbin:/bin',
-		refreshonly => true
-	}
+  exec { 'update_rubygems':
+    path        => '/usr/local/bin:/usr/bin:/usr/sbin:/bin',
+    refreshonly => true
+  }
 
-	package { "ruby":
-		ensure => "present"
-	} ->
-	package { "rubygems-update":
-		ensure => "2.6.8",
-		provider => "gem",
-		notify => Exec["update_rubygems"]
-	} ->
-  package { "rack":
-    ensure => "1.6.6",
-    provider => "gem",
-  } ->
-  package { "vegas":
-    ensure => "0.1.11",
-    provider => "gem",
-  } ->
-  package { "sinatra":
-    ensure => "1.4.8",
-    provider => "gem",
-  } ->
-  package { "net-ssh":
-		ensure => "3.1.1",
-		provider => "gem"
-	} ->
-	package { "capistrano":
-		ensure => "2.15.7",
-		provider => "gem"
-	} ->
-	package { "capistrano-multiconfig":
-		ensure => "0.0.4",
-		provider => "gem"
-	} ->
-	package { "resque":
-		ensure => "1.26.0",
-		provider => "gem"
-	}
+  package { 'ruby':
+    ensure => 'present'
+  }
+  -> package { 'rubygems-update':
+    ensure   => '2.6.8',
+    provider => 'gem',
+    notify   => Exec['update_rubygems']
+  }
+  -> package { 'rack':
+    ensure   => '1.6.6',
+    provider => 'gem',
+  }
+  -> package { 'vegas':
+    ensure   => '0.1.11',
+    provider => 'gem',
+  }
+  -> package { 'sinatra':
+    ensure   => '1.4.8',
+    provider => 'gem',
+  }
+  -> package { 'net-ssh':
+    ensure   => '3.1.1',
+    provider => 'gem'
+  }
+  -> package { 'capistrano':
+    ensure   => '2.15.7',
+    provider => 'gem'
+  }
+  -> package { 'capistrano-multiconfig':
+    ensure   => '0.0.4',
+    provider => 'gem'
+  }
+  -> package { 'resque':
+    ensure   => '1.26.0',
+    provider => 'gem'
+  }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,51 +1,51 @@
 class deploynaut::config inherits deploynaut {
 
-	file {
-		[
-			"${resources_root}/deploynaut-resources",
-			"${resources_root}/deploynaut-resources/envs",
-			"${resources_root}/deploynaut-resources/git",
-			"${resources_root}/deploynaut-resources/logs"
-		]:
-			ensure => "directory",
-			owner => "www-data",
-			group => "www-data",
-			mode => "0755"
-	}
+  file {
+    [
+      "${resources_root}/deploynaut-resources",
+      "${resources_root}/deploynaut-resources/envs",
+      "${resources_root}/deploynaut-resources/git",
+      "${resources_root}/deploynaut-resources/logs"
+    ]:
+      ensure => 'directory',
+      owner  => 'www-data',
+      group  => 'www-data',
+      mode   => '0755'
+  }
 
-	if $composer_user != "www-data" {
+  if $composer_user != 'www-data' {
 
-		user { $composer_user:
-			ensure => "present",
-			managehome => true
-		}->
-		exec { 'add www-data to composer group so that deploynaut can access git keys':
-			command => '/usr/sbin/addgroup www-data composer',
-			unless => "/usr/bin/groups www-data | /bin/grep composer",
-		}->
-		file { "${resources_root}/deploynaut-resources/gitkeys":
-			ensure => "directory",
-			owner => $composer_user,
-			group => $composer_user,
-			mode => "0775"
-			}->
-		file { "/etc/sudoers.d/10_${composer_user}":
-			ensure => file,
-			content => template('deploynaut/sudo_composer.erb'),
-			owner => "root",
-			group => "root",
-			mode => "0440"
-		}
+    user { $composer_user:
+      ensure     => 'present',
+      managehome => true
+    }
+    -> exec { 'add www-data to composer group so that deploynaut can access git keys':
+      command => '/usr/sbin/addgroup www-data composer',
+      unless  => '/usr/bin/groups www-data | /bin/grep composer',
+    }
+    -> file { "${resources_root}/deploynaut-resources/gitkeys":
+      ensure => 'directory',
+      owner  => $composer_user,
+      group  => $composer_user,
+      mode   => '0775'
+      }
+    -> file { "/etc/sudoers.d/10_${composer_user}":
+      ensure  => file,
+      content => template('deploynaut/sudo_composer.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0440'
+    }
 
-	} else {
+  } else {
 
-		file { "${resources_root}/deploynaut-resources/gitkeys":
-			ensure => "directory",
-			owner => $composer_user,
-			group => $composer_user,
-			mode => "0755"
-		}
+    file { "${resources_root}/deploynaut-resources/gitkeys":
+      ensure => 'directory',
+      owner  => $composer_user,
+      group  => $composer_user,
+      mode   => '0755'
+    }
 
-	}
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,23 +1,23 @@
 class deploynaut (
-	$site_root = $deploynaut::params::site_root,
-	$resources_root = $deploynaut::params::resources_root,
-	$service_enable = $deploynaut::params::service_enable,
-	$service_ensure = $deploynaut::params::service_ensure,
-	$service_manage = $deploynaut::params::service_manage,
-	$service_name = $deploynaut::params::service_name,
-	$service_workers = $deploynaut::params::service_workers,
-	$composer_user = $deploynaut::params::composer_user,
-	$composer_source = $deploynaut::params::composer_source,
+  $site_root = $deploynaut::params::site_root,
+  $resources_root = $deploynaut::params::resources_root,
+  $service_enable = $deploynaut::params::service_enable,
+  $service_ensure = $deploynaut::params::service_ensure,
+  $service_manage = $deploynaut::params::service_manage,
+  $service_name = $deploynaut::params::service_name,
+  $service_workers = $deploynaut::params::service_workers,
+  $composer_user = $deploynaut::params::composer_user,
+  $composer_source = $deploynaut::params::composer_source,
 ) inherits deploynaut::params {
 
-	validate_string($site_root)
-	validate_string($resources_root)
-	if $composer_user != undef {
-		validate_string($composer_user)
-	}
+  validate_string($site_root)
+  validate_string($resources_root)
+  if $composer_user != undef {
+    validate_string($composer_user)
+  }
 
-	class { "deploynaut::install": }->
-	class { "deploynaut::config": }->
-	class { "deploynaut::service": }
+  class { 'deploynaut::install': }
+  -> class { 'deploynaut::config': }
+  -> class { 'deploynaut::service': }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,16 +1,16 @@
 class deploynaut::install inherits deploynaut {
 
-	package { "redis-server":
-		ensure => present
-	}
-	package { "redis-tools":
-		ensure => present
-	}
-	servicetools::install_file { "/usr/local/bin/composer":
-		source => $composer_source,
-		owner => "root",
-		group => "root",
-		mode => "0755"
-	}
+  package { 'redis-server':
+    ensure => present
+  }
+  package { 'redis-tools':
+    ensure => present
+  }
+  servicetools::install_file { '/usr/local/bin/composer':
+    source => $composer_source,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755'
+  }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,13 +1,13 @@
 class deploynaut::params(
-	$site_root = undef,
-	$resources_root = undef,
-	$service_enable = true,
-	$service_ensure = "running",
-	$service_manage = true,
-	$service_name = "php-resque",
-	$service_workers = "4",
-	$composer_user = "www-data",
-	$composer_source = "https://getcomposer.org/download/1.4.1/composer.phar",
+  $site_root = undef,
+  $resources_root = undef,
+  $service_enable = true,
+  $service_ensure = 'running',
+  $service_manage = true,
+  $service_name = 'php-resque',
+  $service_workers = '4',
+  $composer_user = 'www-data',
+  $composer_source = 'https://getcomposer.org/download/1.4.1/composer.phar',
 ) {
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,23 +1,23 @@
 class deploynaut::service inherits deploynaut {
 
-	validate_string($service_name)
-	validate_bool($service_enable)
+  validate_string($service_name)
+  validate_bool($service_enable)
 
-	if !($service_ensure in ['running', 'stopped']) {
-		fail('service_ensure parameter must be running or stopped')
-	}
+  if !($service_ensure in ['running', 'stopped']) {
+    fail('service_ensure parameter must be running or stopped')
+  }
 
-	if $service_manage {
-		servicetools::install_systemd_unit { $service_name:
-			service_options => {
-				"Type" => "forking",
-				"ExecStart" => "/usr/bin/php ${site_root}/framework/cli-script.php dev/resque/run queue=* count=${service_workers} flush=1",
-				"User" => "www-data",
-				"Restart" => "on-failure"
-			},
-			service_ensure => $service_ensure,
-			service_enable => $service_enable
-		}
-	}
+  if $service_manage {
+    servicetools::install_systemd_unit { $service_name:
+      service_options => {
+        'Type'      => 'forking',
+        'ExecStart' => "/usr/bin/php ${site_root}/framework/cli-script.php dev/resque/run queue=* count=${service_workers} flush=1",
+        'User'      => 'www-data',
+        'Restart'   => 'on-failure'
+      },
+      service_ensure  => $service_ensure,
+      service_enable  => $service_enable
+    }
+  }
 
 }


### PR DESCRIPTION
This doesn't work.. but

If making a Gemfile like this and run it with bundler it works
```
source "https://rubygems.org"

ruby "2.1.5"

gem "net-ssh", "= 3.1.1"
gem "capistrano", "= 2.15.7"
gem "capistrano-multiconfig", "= 0.0.4"
gem "resque", "= 1.26.0"
gem "rack", "1.6.6"
```

this seems to install these version
```
Using highline 1.7.8
Using net-ssh 3.1.1
Using mono_logger 1.1.0
Using multi_json 1.12.1
Using rack 1.6.6
Using redis 3.3.3
Using tilt 2.0.7
Using bundler 1.14.6
Using net-scp 1.2.1
Using net-sftp 2.1.2
Using net-ssh-gateway 1.3.0
Using rack-protection 1.5.3
Using vegas 0.1.11
Using redis-namespace 1.5.3
Using capistrano 2.15.7
Using sinatra 1.4.8
Using capistrano-multiconfig 0.0.4
Using resque 1.26.0
```

I've tested this in an vagrant box and still.. 

