### PR TITLE
pin redis and redis-server gems

### DIFF
--- a/manifests/capistrano.pp
+++ b/manifests/capistrano.pp
@@ -13,6 +13,14 @@ class deploynaut::capistrano {
     provider => 'gem',
     notify   => Exec['update_rubygems']
   }
+  -> package { 'redis':
+    ensure   => '3.3.5',
+    provider => 'gem'
+  }
+  -> package { 'redis-namespace':
+    ensure   => '1.5.3',
+    provider => 'gem'
+  }
   -> package { 'rack':
     ensure   => '1.6.6',
     provider => 'gem',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,10 +1,10 @@
 class deploynaut::install inherits deploynaut {
 
   package { 'redis-server':
-    ensure => present
+    ensure => '2:2.8.17-1+deb8u5'
   }
   package { 'redis-tools':
-    ensure => present
+    ensure => '2:2.8.17-1+deb8u5'
   }
   servicetools::install_file { '/usr/local/bin/composer':
     source => $composer_source,


### PR DESCRIPTION
Was trying to install some updated version of redis that required ruby 2.2.2 - which isn't natively available on Jessie. This pins those two gems to the versions currently installed, and the same with the `apt` packages.