### PR TITLE
Move composer to a symlink so new versions are used automatically.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,8 +6,17 @@ class deploynaut::install inherits deploynaut {
   package { 'redis-tools':
     ensure => present
   }
-  servicetools::install_file { '/usr/local/bin/composer':
-    source => $composer_source,
+
+  $composer_path = "/usr/local/bin/composer-${composer_version}"
+  servicetools::install_file { $composer_path:
+    source => "https://getcomposer.org/download/${composer_version}/composer.phar",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755'
+  } ->
+  file { '/usr/local/bin/composer':
+    ensure => link,
+    target => $composer_path,
     owner  => 'root',
     group  => 'root',
     mode   => '0755'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class deploynaut::params(
   $service_name = 'php-resque',
   $service_workers = '4',
   $composer_user = 'www-data',
-  $composer_source = 'https://getcomposer.org/download/1.6.5/composer.phar',
+  $composer_version = '1.8.6',
 ) {
 
 }


### PR DESCRIPTION
Servicetools will not replace a file if it already exists, so us changing the Composer version path has no effect. This change will save it as its own file, and ensure the `composer` executable is symlinked to the version we've set.