### PR TITLE
Introduce staggered php-resque worker restarts.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,14 +7,7 @@ class deploynaut::service inherits deploynaut {
     fail('service_ensure parameter must be running or stopped')
   }
 
-  if ($service_enable or $service_ensure=='running') {
-    $first_surplus_worker = $service_workers + 1
-  } else {
-    # Disable all.
-    $first_surplus_worker = 1
-  }
-  # Force to int
-  $last_wanted_worker = 0 + $service_workers
+  $workers = range("1", $service_workers)
 
   File {
     ensure => file,
@@ -26,34 +19,15 @@ class deploynaut::service inherits deploynaut {
 
   # Manage N workers through systemd, so that we can get systemd to gracefully restart them.
   if $service_manage {
-
     file { "/etc/systemd/system/$service_name-flush.service":
       content => template("deploynaut/systemd_flush_service.erb"),
     } ->
-    file { "/etc/systemd/system/$service_name@.service":
-      # @ is required to be able to launch multiple aliased copies of the same service.
-      content => template("deploynaut/systemd_service.erb"),
+    deploynaut::worker_unit{$workers:
+      service_name => $service_name,
+      notify => Exec['deploynaut systemctl daemon reload'],
     } ->
     file { "/etc/systemd/system/$service_name.target":
       content => template("deploynaut/systemd_target.erb"),
-    }
-
-    $surplus_workers_pattern = "$service_name@{$first_surplus_worker..99}.service"
-    exec { "Remove surplus workers ($first_surplus_worker..99)":
-      # Disable and stop surplus workers. Systemd wouldn't know how to do that.
-      command => "/bin/bash -c '/bin/systemctl disable $surplus_workers_pattern; /bin/systemctl stop $surplus_workers_pattern; /bin/systemctl reset-failed'",
-      onlyif => "[ -f '/etc/systemd/system/$service_name.target.wants/php-resque@$first_surplus_worker.service' ]",
-      provider => 'shell',
-      require => File["/etc/systemd/system/$service_name@.service"],
-      notify => Exec['deploynaut systemctl daemon reload'],
-    } ->
-    exec { "Add workers (1..$last_wanted_worker)":
-      # Force target to re-enable, which will take care of adding workers.
-      command => "/bin/systemctl disable $service_name.target",
-      creates => "/etc/systemd/system/$service_name.target.wants/php-resque@$last_wanted_worker.service",
-      provider => 'shell',
-      require => File["/etc/systemd/system/$service_name@.service"],
-      notify => Exec['deploynaut systemctl daemon reload'],
     }
 
     exec { 'deploynaut systemctl daemon reload':

--- a/manifests/worker_unit.pp
+++ b/manifests/worker_unit.pp
@@ -1,0 +1,12 @@
+define deploynaut::worker_unit(
+  $service_name = 'php-resque',
+) {
+  $unit_name = "$service_name-$name"
+  if $name != 1 {
+    $prev_unit = $name - 1
+    $prev_unit_name = "$service_name-$prev_unit"
+  }
+  file { "/etc/systemd/system/$unit_name.service":
+    content => template("deploynaut/systemd_service.erb"),
+  }
+}

--- a/templates/systemd_flush_service.erb
+++ b/templates/systemd_flush_service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=<%= @service_name %>-flush
-BindsTo=<%= @service_name %>.target
+PartOf=<%= @service_name %>.target
 
 [Service]
 Type=oneshot

--- a/templates/systemd_service.erb
+++ b/templates/systemd_service.erb
@@ -1,25 +1,24 @@
-# Please note systemd now controls multiple workers directly.
 # Control of all workers jointly is done through the <%= @service_name %>.target.
 #
 # To restart all workers:
 #   systemctl restart <%= @service_name %>.target
 # To restart one particular worker:
-#   systemctl restart <%= @service_name %>@1.service
+#   systemctl restart <%= @unit_name %>.service
 #
 
 [Unit]
-Description=<%= @service_name %>
-BindsTo=<%= @service_name %>.target
-After=<%= @service_name %>-flush.service
+Description=<%= @unit_name %>
+PartOf=<%= @service_name %>.target
+After=<%= @service_name %>-flush.service<% if @prev_unit_name %> <%= @prev_unit_name %>.service<% end %>
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/php <%= @site_root %>/framework/cli-script.php dev/resque/run queue=* count=1
 User=www-data
 Restart=on-failure
-SyslogIdentifier=<%= @service_name %>
+SyslogIdentifier=<%= @unit_name %>
 
-# Sending SIGQUIT ensures the worker exits gracefully: it signals <%= @service_name %> to terminate after
+# Sending SIGQUIT ensures the worker exits gracefully: it signals <%= @unit_name %> to terminate after
 # the current job has finished. To have this work properly, we must use KillMode=process, otherwise
 # subshells will be terminated (and the job will die).
 KillMode=process

--- a/templates/systemd_target.erb
+++ b/templates/systemd_target.erb
@@ -1,10 +1,10 @@
 [Unit]
 After=syslog.target network.target
-Requires=<%= @service_name %>-flush.service <% for w in 1..scope.lookupvar('last_wanted_worker') do %>php-resque@<%= w %>.service <% end %>
+Wants=<%= @service_name %>-flush.service <% for w in @workers do %><%= @service_name %>-<%= w %>.service <% end %>
 # Force this target to block upon "stop", until all workers have gracefully exited.
 # This makes it easier to write deploy scripts that rely on php-resque being stopped.
-Before=<%= @service_name %>-flush.service <% for w in 1..scope.lookupvar('last_wanted_worker') do %>php-resque@<%= w %>.service <% end %>
+Before=<%= @service_name %>-flush.service <% for w in @workers do %><%= @service_name %>-<%= w %>.service <% end %>
 
 [Install]
 WantedBy=multi-user.target
-Also=<% for w in 1..scope.lookupvar('last_wanted_worker') do %>php-resque@<%= w %>.service <% end %>
+Also=<% for w in @workers do %><%= @service_name %>-<%= w %>.service <% end %>


### PR DESCRIPTION
Set the dependency chain up, so that we don't end up with apparent dash
outage when no tasks are being processed for a while because it's
waiting for a fat deploy or snapshot to complete.