### PR TITLE
Script for staggered restarts of resque workers.

### DIFF
--- a/templates/systemd_flush_service.erb
+++ b/templates/systemd_flush_service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=<%= @service_name %>-flush
-BindsTo=<%= @service_name %>.target
+PartOf=<%= @service_name %>.target
 
 [Service]
 Type=oneshot

--- a/templates/systemd_service.erb
+++ b/templates/systemd_service.erb
@@ -9,7 +9,7 @@
 
 [Unit]
 Description=<%= @service_name %>
-BindsTo=<%= @service_name %>.target
+PartOf=<%= @service_name %>.target
 After=<%= @service_name %>-flush.service
 
 [Service]

--- a/templates/systemd_target.erb
+++ b/templates/systemd_target.erb
@@ -1,6 +1,6 @@
 [Unit]
 After=syslog.target network.target
-Requires=<%= @service_name %>-flush.service <% for w in 1..scope.lookupvar('last_wanted_worker') do %>php-resque@<%= w %>.service <% end %>
+Wants=<%= @service_name %>-flush.service <% for w in 1..scope.lookupvar('last_wanted_worker') do %>php-resque@<%= w %>.service <% end %>
 # Force this target to block upon "stop", until all workers have gracefully exited.
 # This makes it easier to write deploy scripts that rely on php-resque being stopped.
 Before=<%= @service_name %>-flush.service <% for w in 1..scope.lookupvar('last_wanted_worker') do %>php-resque@<%= w %>.service <% end %>


### PR DESCRIPTION
Prevent apparent dash outage when no tasks are being processed for a
while because it's waiting for a fat deploy or snapshot to complete.